### PR TITLE
Disable production CI

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -5,7 +5,7 @@ name: Deploy to Firebase Hosting on merge
 'on':
   push:
     branches:
-      - main
+      - this-should-be-main-when-we-want-to-re-enable-it
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR disables CI for the "production" deployment step.  Once the deployment is fixed to include styles this can be re-enabled.

Issue #4 Fix CI / CD